### PR TITLE
Avoid exception in duration calculation.

### DIFF
--- a/liblrt.py
+++ b/liblrt.py
@@ -108,6 +108,8 @@ def getVideoStreamURL(url):
   return result
 
 def str_duration_to_int(duration):
+  if not duration:
+    return 0
   
   parts = duration.split(':')
   if not parts:

--- a/test_liblrt.lt
+++ b/test_liblrt.lt
@@ -44,6 +44,10 @@ def test4():
 def test5():
   print "test5()"
   print lrt.getTVShowsList()
+  
+def test6():
+  print "test6() Auksinis protas"
+  print lrt.getTVShowVideos(92)
 
 if __name__ == '__main__':
   if len(sys.argv) > 1:
@@ -60,3 +64,5 @@ if __name__ == '__main__':
       test4()
     elif n == 5:
       test5()
+    elif n == 6:
+      test6()


### PR DESCRIPTION
Media programs return wrong 'end' value (null/None).
Return zero in that case and continue returning list.
Added test6() to test particular program list.

Signed-off-by: Tomas Gudauskas (Zmogas) <zmogas@gmail.com>